### PR TITLE
Remove post-attach script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,9 +40,5 @@
         "runtimeverification.simbolik"
       ]
     }
-  },
-  // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": ""
-  // Use 'postAttachCommand' to attach a command after the container is opened.
-  "postAttachCommand": "git remote remove upstream || true"
+  }
 }


### PR DESCRIPTION
This PR removes the postAttach script that was responsible for deleting git's "upstream"-branch after container creation. Since, container creation is now done through GitHub's native creation page (see: https://github.com/solarspace-dev/solarspace.dev/pull/2) this is no longer needed and can be removed.