### PR TITLE
Allow disabling docker build cache

### DIFF
--- a/.github/workflows/publish-devcontainer.yml
+++ b/.github/workflows/publish-devcontainer.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      no-cache:
+        description: 'Disable Docker build cache?'
+        required: false
+        default: 'false'  # Cache enabled by default
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 jobs:
 
@@ -31,3 +41,4 @@ jobs:
           file: .devcontainer/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
+          no-cache: ${{ github.event.inputs.no-cache == 'true' }}


### PR DESCRIPTION
This PR adds an option to rebuild the dev container without a cache. The goal is to rebuild with the latest tool versions. In the future, we can refine this and make tool versions explicit instead of implicit.