### PR TITLE
Add Claude Code to the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,8 +18,22 @@
   // Writable mounts in case you want to set --read-only above.
   "mounts": [
   ],
-  
-  
+
+  // Make the Anthropic API key available to Claude Code.
+  // In GitHub Codespaces, add a Codespaces secret named ANTHROPIC_API_KEY
+  // (repo or user level); it is injected here via localEnv. If unset, this
+  // is empty and Claude Code will fall back to interactive `claude login`.
+  "containerEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
+  },
+
+  // Install the Claude Code CLI after the container is created. Done here
+  // (not in the Dockerfile) so it works with the prebuilt ghcr.io image
+  // and in GitHub Codespaces without rebuilding/republishing the image.
+  // Interactive bash so the image's nvm-managed node/npm are on PATH.
+  "postCreateCommand": "bash -ic 'npm install -g @anthropic-ai/claude-code'",
+
+
   // Configure tool-specific properties.
   "customizations": {
     // Configure properties specific to VS Code.
@@ -37,7 +51,8 @@
         "solarspace.solarspace",
         "juanblanco.solidity",
         "trailofbits.weaudit",
-        "runtimeverification.simbolik"
+        "runtimeverification.simbolik",
+        "anthropic.claude-code"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -2,3 +2,32 @@
 
 The Solar Space Devcontainer provides a pre-configured development environment for
 Ethereum projects.
+
+## Claude Code
+
+[Claude Code](https://claude.ai/code) is included in this devcontainer. It is installed automatically after the container is created and is available as the `claude` CLI and as a VS Code extension (`anthropic.claude-code`).
+
+### Authentication
+
+**GitHub Codespaces (recommended):** Add a [Codespaces secret](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-secrets-for-your-codespaces) named `ANTHROPIC_API_KEY` and grant it access to this repository. The secret is automatically injected into the container — no manual login required.
+
+**Local devcontainer:** Set `ANTHROPIC_API_KEY` in your local environment before starting the container. The devcontainer will pick it up automatically.
+
+**Without an API key:** Claude Code will still install, but you will need to run `claude login` inside the terminal to authenticate interactively.
+
+### Usage
+
+Once authenticated, open a terminal in the devcontainer and run:
+
+```bash
+# Start an interactive session
+claude
+
+# Ask a one-off question
+claude "Explain what this contract does"
+
+# Work on a specific file
+claude --file src/MyContract.sol "Review this for security issues"
+```
+
+The VS Code extension provides the same capabilities directly from the editor sidebar.


### PR DESCRIPTION
## Summary

Lightweight, GitHub Codespaces-compatible integration of Claude Code into the existing Solar Space devcontainer. Additive only — Ethereum tooling, telemetry killswitches, and the prebuilt-image setup are untouched.

Changes to `.devcontainer/devcontainer.json`:
- **`postCreateCommand`** installs `@anthropic-ai/claude-code` via npm after container creation. Runs in interactive bash so the image's nvm-managed node/npm are on PATH (mirrors how the Dockerfile installs pnpm/hardhat). Works with the prebuilt `ghcr.io` image without a rebuild.
- **`containerEnv.ANTHROPIC_API_KEY`** wired from `localEnv` so a Codespaces secret flows through; falls back to interactive `claude login` if unset.
- **`anthropic.claude-code`** added to VS Code extensions.

## Deliberately omitted

The official reference devcontainer's `init-firewall.sh` and persistent `~/.claude` named volume are **non-functional in GitHub Codespaces** (no `NET_ADMIN`; only `/workspaces` persists), so they were left out by design.

## Manual step required

For Codespaces auth, add a Codespaces secret named `ANTHROPIC_API_KEY` granted to this repo. Without it the CLI still installs but each Codespace needs an interactive `claude login`.

## Testing

Not verified by an actual container build — `postCreateCommand` is modeled on the existing working Dockerfile pattern but should be confirmed in a Codespace / local devcontainer build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)